### PR TITLE
added more functionality to writeCSV()

### DIFF
--- a/PhyPraKit/PhyPraKit.py
+++ b/PhyPraKit/PhyPraKit.py
@@ -87,6 +87,8 @@ from __future__ import print_function  # for python2.7 compatibility
 #                       as in all other fit interfaces
 #   27-July-17   GQ  added convolutionEdgefinder() and refactored
 #                    convolutionPeakfinder() to use similar components
+#   05-Feb-19    CV  added line ending chars to createCSV(), to export
+#                    data for example as a latex table
 # ----------------------------------------------------------------------
 
 import numpy as np, matplotlib.pyplot as plt
@@ -429,7 +431,7 @@ def labxParser(file, prlevel=1):
   return vtags, varray
 
 
-def writeCSV(file, ldata, hlines=[], fmt='%.10g'):
+def writeCSV(file, ldata, hlines=[], fmt='%.10g', delim=',', nline='\n'):
   '''
   write data in .csv format, including header lines
   
@@ -438,6 +440,8 @@ def writeCSV(file, ldata, hlines=[], fmt='%.10g'):
     * ldata: list of columns to be written
     * hlines: list with header lines (optional)
     * fmt: format string (optional)
+    * delim: delimiter to seperate values (default comma)
+    * nline: newline string (default: \n)
 
   Returns: 
     * 0/1  for success/fail
@@ -448,16 +452,20 @@ def writeCSV(file, ldata, hlines=[], fmt='%.10g'):
   # open file for read (if necessary)
   if type(file)==type(' '): f = open(file, 'w') # file is a file name
   else: f=file     # assume input is file handle of an open file 
+  
+  #check if \n is contained in newline, if not add it
+  if "\n" not in nline:
+    nline += "\n"
 
   if type(hlines)==type(' '):
-     f.write(hlines+'\n')
+     f.write(hlines+nline)
   elif type(hlines)==type([]):
     for i in range(len(hlines)):
-      f.write(hlines[i]+'\n')
+      f.write(hlines[i]+nline)
 
   try:
     np.savetxt(f, np.array(ldata).transpose(),
-                fmt=fmt, delimiter =',', newline='\n')
+                fmt=fmt, delimiter=delim, newline=nline)
     return 0
   except:
     return 1

--- a/PhyPraKit/PhyPraKit.py
+++ b/PhyPraKit/PhyPraKit.py
@@ -431,7 +431,7 @@ def labxParser(file, prlevel=1):
   return vtags, varray
 
 
-def writeCSV(file, ldata, hlines=[], fmt='%.10g', delim=',', nline='\n'):
+def writeCSV(file, ldata, hlines=[], fmt='%.10g', delim=',', nline='\n', **kwargs):
   '''
   write data in .csv format, including header lines
   
@@ -465,10 +465,40 @@ def writeCSV(file, ldata, hlines=[], fmt='%.10g', delim=',', nline='\n'):
 
   try:
     np.savetxt(f, np.array(ldata).transpose(),
-                fmt=fmt, delimiter=delim, newline=nline)
+                fmt=fmt, delimiter=delim, newline=nline, **kwargs)
     return 0
   except:
     return 1
+
+def writeTexTable(file, ldata, cnames=[], fmt='%.10g'):
+  ''' write data formatted as latex tabular
+
+  Args:
+    * file: string, file name
+    * ldata: list of columns to be written
+    * cnames: list of column names (optional)
+    * fmt: format string (optional)
+  
+  Returns:
+    * 0/1 for success/fail
+  '''
+  delim = " & "
+  nline = "\\\\\n"
+
+  #create header for latex tabular environment
+  head = "\\begin{tabular}{"+len(ldata)*"c"+"}\n"
+  if type(cnames)==type(''):
+    head += cnames
+  elif type(cnames)==type([]) and len(cnames)>0:
+    for element in cnames:
+      head += element + " & "
+    head = head[:-3]
+  #create footer
+  foot = "\\end{tabular}"
+  #write file, comments ahs to be empty because of numpy putting a comment symbol
+  #in front of the header and footer
+  return writeCSV(file, ldata, fmt=fmt, delim=delim, nline=nline,
+                  header=head, footer=foot, comments='')
 
 ## ------- section 2: statistics  -----------------------
 


### PR DESCRIPTION
Added the option to specify a delimiter and a newline symbol in `writeCSV()` as well as introducing `**kwargs` to use with `np.savetxt()`.
Added `writeTexTable()` to generate a latex tabular environment already populated with data from the given input arrays.
Example:
`writeTexTable('table.tex', data, ['column1_name', 'column2_name'])`