### PR TITLE
estimate y-error in linRegression

### DIFF
--- a/PhyPraKit/PhyPraKit.py
+++ b/PhyPraKit/PhyPraKit.py
@@ -1147,10 +1147,10 @@ def linRegression(x, y, sy=None):
       * float: chi2  \chi-square
   """
 
+  estimate_sigma=sy is None
   # set y-errors to 1. if not given
-  if sy is None:
+  if estimate_sigma:
     sy=np.ones(len(y))
-    print('\n!**! No y-errors given -> parameter errors from fit are meaningless!\n')
 
   # calculate auxilary quantities
   S1  = sum(1./sy**2)
@@ -1168,6 +1168,11 @@ def linRegression(x, y, sy=None):
   cov   = -Sx/D
   cor  = cov/(sa*sb)
   chi2  = sum(((y-(a*x+b))/sy)**2)
+
+  # approximate y-errors from chi2 with n-2 degrees of freedom if not given
+  if estimate_sigma:
+    sigma_estimated=np.sqrt(chi2/(len(y) - 2))
+    return linRegression(x, y, np.repeat(sigma_estimated, len(y)))
 
   return a, b, sa, sb, cor, chi2
 


### PR DESCRIPTION
Instead of assuming the y-errors to be equal to 1 if none are provided, a chi2 distribution with n-2 degrees of freedom is assumed to estimate the standard deviation of y.

This imitates the behaviour of scipy's `linregress` or any other textbook linear regression.

The following script can be used to verify that the linear regression from PhyPraKit now behaves exactly like scipy's:

```Python
import numpy as np
from PhyPraKit import linRegression
from scipy.stats import linregress

x = np.arange(0, 10, 1)
y = np.random.normal(x, 0.1) + 1

a, b, sa, _, _, _ = linRegression(x, y)
m, c, _, _, sm  = linregress(x, y)

print("y = ({:1.2f} ± {:1.5f})x + {:1.1f}".format(a, sa, b))
print("y = ({:1.2f} ± {:1.5f})x + {:1.1f}".format(m, sm, c))
```